### PR TITLE
Add a few items

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -12,3 +12,6 @@ rustflags = [
     # LLVM linker:
     "-C", "link-arg=-Map=build.map",
 ]
+
+[unstable]
+build-std = ["core", "alloc"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,7 +455,7 @@ dependencies = [
  "embedded-alloc",
  "nrf52840-hal",
  "panic-rtt-target",
- "rtt-target 0.4.0",
+ "rtt-target",
 ]
 
 [[package]]
@@ -623,11 +623,10 @@ dependencies = [
 [[package]]
 name = "panic-rtt-target"
 version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d6ab67bc881453e4c90f958c657c1303670ea87bc1a16e87fd71a40f656dce9"
+source = "git+https://github.com/probe-rs/rtt-target?rev=59b236ce50e44826031adbfc12742e4a0b8d5d6c#59b236ce50e44826031adbfc12742e4a0b8d5d6c"
 dependencies = [
  "cortex-m",
- "rtt-target 0.3.1",
+ "rtt-target",
 ]
 
 [[package]]
@@ -677,18 +676,8 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "rtt-target"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "065d6058bb1204f51a562a67209e1817cf714759d5cf845aa45c75fa7b0b9d9b"
-dependencies = [
- "ufmt-write",
-]
-
-[[package]]
-name = "rtt-target"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3afa12c77ba1b9bf560e4039a9b9a08bb9cde0e9e6923955eeb917dd8d5cf303"
+source = "git+https://github.com/probe-rs/rtt-target?rev=59b236ce50e44826031adbfc12742e4a0b8d5d6c#59b236ce50e44826031adbfc12742e4a0b8d5d6c"
 dependencies = [
  "critical-section",
  "ufmt-write",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,9 +28,12 @@ debug = true
 debug-assertions = true # controls both our own assertions plus whether RTT enabled
 overflow-checks = false
 lto = 'fat' # same as true? may do nothing if codegen-units is 1
+# lto = false # same as true? may do nothing if codegen-units is 1
+# lto = 'thin' # same as true? may do nothing if codegen-units is 1
 panic = 'abort'
-incremental = true
-codegen-units = 8
+incremental = false
+# codegen-units = 8
+codegen-units = 1
 
 #-----------------------------------
 [dependencies]
@@ -46,8 +49,11 @@ critical-section = { version = "1.1", default-features = false }
 nrf52840-hal = { version = "0.16.0" }
 
 embedded-alloc = "0.5.0"
-panic-rtt-target = { version = "0.1.2", features = ["cortex-m"] }
-rtt-target = { version = "0.4.0" }
+# panic-rtt-target = { version = "0.1.2", features = ["cortex-m"] }
+# rtt-target = { version = "0.3.1", features = ["cortex-m"] }
+
+panic-rtt-target = { git = "https://github.com/probe-rs/rtt-target", rev = "59b236ce50e44826031adbfc12742e4a0b8d5d6c", features = ["cortex-m"] }
+rtt-target = { git = "https://github.com/probe-rs/rtt-target", rev = "59b236ce50e44826031adbfc12742e4a0b8d5d6c" }
 
 [patch.crates-io]
 # Note: latest known good version is whatever comes after rev = below.
@@ -55,3 +61,4 @@ embassy-executor = { git = "https://github.com/embassy-rs/embassy", rev="ce66276
 embassy-nrf = { git = "https://github.com/embassy-rs/embassy", rev="ce66276" }
 embassy-sync = { git = "https://github.com/embassy-rs/embassy", rev="ce66276" }
 embassy-time = { git = "https://github.com/embassy-rs/embassy", rev="ce66276" }
+rtt-target = { git = "https://github.com/probe-rs/rtt-target", rev = "59b236ce50e44826031adbfc12742e4a0b8d5d6c" }

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,10 @@
+set -euxo pipefail
+
+cargo build
+cargo objcopy -- -O ihex none-fault.hex
+sleep 1
+probe-rs download --chip nrf52840 --format hex none-fault.hex
+sleep 1
+probe-rs reset --chip nrf52840
+RTT=$(grep _SEGGER_RTT$ build.map | cut -d' ' -f1); echo $RTT >.rttlast
+rtthost --chip nrf52840 --scan-region 0x$RTT


### PR DESCRIPTION
* converges rtt deps to endure only rtt-target v0.4.0 is used
    * I think this was the source of your "already borrowed" issue 
* builds std to get more debug info
* tweaks some profile items